### PR TITLE
Update cfg-if to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ categories = ["api-bindings","os"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cfg-if = "0.*"
-num_cpus = "1.*"
+cfg-if = "1"
+num_cpus = "1"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 libc = "0.*"


### PR DESCRIPTION
This updates cfg-if to `1.0` as well as changes the `1.*` dependency to `^1` which is equivalent.

Thanks for the work on this library!